### PR TITLE
add python-version distance calc SCs

### DIFF
--- a/python/Distance_SC.py
+++ b/python/Distance_SC.py
@@ -1,0 +1,88 @@
+import numpy as np
+def distance_sc(sc1, sc2):
+    num_sectors = sc1.shape[1]
+    # repeate to move 1 columns
+    sim_for_each_cols = np.zeros(num_sectors)
+
+    for i in range(num_sectors):
+        # Shift
+        one_step = 1 # const
+        sc1 = np.roll(sc1, one_step, axis=1) #  columne shift
+
+        #compare
+        sum_of_cos_sim = 0
+        num_col_engaged = 0
+
+        for j in range(num_sectors):
+            col_j_1 = sc1[:, j]
+            col_j_2 = sc2[:, j]
+
+            if (~np.any(col_j_1) or ~np.any(col_j_2)):
+                continue
+
+            # calc sim
+            cos_similarity = np.dot(col_j_1, col_j_2) / (np.linalg.norm(col_j_1) * np.linalg.norm(col_j_2))
+            sum_of_cos_sim = sum_of_cos_sim + cos_similarity
+
+            num_col_engaged = num_col_engaged + 1
+
+        # devided by num_col_engaged: So, even if there are many columns that are excluded from the calculation, we
+        # can get high scores if other columns are well fit.
+        sim_for_each_cols[i] = sum_of_cos_sim / num_col_engaged
+
+    sim = max(sim_for_each_cols)
+
+    dist = 1 - sim
+
+    return dist
+
+if __name__ == "__main__":
+    from python.make_sc_example import *
+    bin_dir = '../sample_data/KITTI/00/velodyne/'
+    bin_db = kitti_vlp_database(bin_dir)
+    SCs = []
+    for bin_idx in range(bin_db.num_bins):
+        bin_file_name = bin_db.bin_files[bin_idx]
+        bin_path = bin_db.bin_dir + bin_file_name
+
+        sc = ScanContext(bin_dir, bin_file_name)
+
+        # fig_idx = 1
+        # # sc.plot_multiple_sc(fig_idx)
+        #
+        # print(len(sc.SCs))
+
+        SCs.append(sc.SCs[0])
+
+    sc_1a = SCs[0]
+    sc_1b = SCs[1]
+    sc_2a = SCs[2]
+    sc_2b = SCs[3]
+
+    dist_1a_1b = distance_sc(sc_1a, sc_1b)
+    dist_1b_2a = distance_sc(sc_1b, sc_2a)
+    dist_1a_2a = distance_sc(sc_1a, sc_2a)
+    dist_2a_2b = distance_sc(sc_2a, sc_2b)
+
+    print("--------------------")
+    print(dist_1a_1b)
+    print(dist_1b_2a)
+    print(dist_1a_2a)
+    print(dist_2a_2b)
+
+    # The scancontext results generated from 'make_sc_example.py' is a little different with 'Ptcloud2ScanContext.m'
+    # Don't know why
+
+    # python result
+    # 0.10860358309493079
+    # 0.4954163429642825
+    # 0.4809364940958847
+    # 0.13027243597096394
+
+    # matlab result
+    # 0.1426
+    # 0.5109
+    # 0.4902
+    # 0.1151
+
+

--- a/python/make_sc_example.py
+++ b/python/make_sc_example.py
@@ -22,8 +22,10 @@ class ScanContext:
     
     kitti_lidar_height = 2.0;
     
-    sector_res = np.array([45, 90, 180, 360, 720])
-    ring_res = np.array([10, 20, 40, 80, 160])
+    # sector_res = np.array([45, 90, 180, 360, 720])
+    # ring_res = np.array([10, 20, 40, 80, 160])
+    sector_res = np.array([60])
+    ring_res = np.array([20])
     max_length = 80
     
      
@@ -116,7 +118,7 @@ class ScanContext:
         downpcd = voxel_down_sample(pcd, voxel_size = ScanContext.downcell_size)
         ptcloud_xyz_downed = np.asarray(downpcd.points)
         print("The number of downsampled points: " + str(ptcloud_xyz_downed.shape) ) 
-        draw_geometries([downpcd])
+        # draw_geometries([downpcd])
     
         if(ScanContext.viz):
             draw_geometries([downpcd])
@@ -156,8 +158,11 @@ if __name__ == "__main__":
         sc = ScanContext(bin_dir, bin_file_name)
 
         fig_idx = 1
-        sc.plot_multiple_sc(fig_idx)
-        
+        # sc.plot_multiple_sc(fig_idx)
+
+        print(len(sc.SCs))
+        print(sc.SCs[0].shape)
+
         
         
         


### PR DESCRIPTION
Hi!
I add  the python-version of calculating distance between two ScanContexts. Modified from 'DistanceBtnScanContexts.m'.
I set the SC size with 20x60 as the basic.m does, but I find the ScanContexts generated from 'make_sc_example.py' is a little different with 'Ptcloud2ScanContext.m'. So the final distance between the python version and matlab  version is a little different. I think the implementation of 'Distance_SC.py' is OK. Could you help me figure it out?
Thanks a lot!

Results:
    # python result
    # 0.10860358309493079
    # 0.4954163429642825
    # 0.4809364940958847
    # 0.13027243597096394

    # matlab result
    # 0.1426
    # 0.5109
    # 0.4902
    # 0.1151
 